### PR TITLE
Update readme to include possible hawtbuf requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Producer.
 - A JMS Broker (Example: [Apache ActiveMQ](http://activemq.apache.org/getting-started.html))
   * After installing the JMS broker, copy its .jar files into the `<BALLERINA_HOME>/bre/lib` folder
     * For ActiveMQ 5.12.0: Copy `activemq-client-5.12.0.jar` and `geronimo-j2ee-management_1.1_spec-1.0.1.jar`
-    * Later versions of ActiveMQ (eg:- ActiveMQ 5.14.0) may additionally require copying `hawtbuf-1.11.jar`
+    * Later versions of ActiveMQ (e.g., ActiveMQ 5.14.0) may additionally require copying `hawtbuf-1.11.jar`
 - A Text Editor or an IDE 
 
 ### Optional Requirements

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Producer.
 - A JMS Broker (Example: [Apache ActiveMQ](http://activemq.apache.org/getting-started.html))
   * After installing the JMS broker, copy its .jar files into the `<BALLERINA_HOME>/bre/lib` folder
     * For ActiveMQ 5.12.0: Copy `activemq-client-5.12.0.jar` and `geronimo-j2ee-management_1.1_spec-1.0.1.jar`
+    * Later versions of ActiveMQ (eg:- ActiveMQ 5.14.0) may additionally require copying `hawtbuf-1.11.jar`
 - A Text Editor or an IDE 
 
 ### Optional Requirements


### PR DESCRIPTION
## Purpose
To run this guide with later version of ActiveMQ, the hawtbuf jar may also have to be copied in addition to the mentioned jars.

Without the hawtbuf jar, running the guide with **ActiveMQ 5.14.5** fails with 
```cmd
ballerina: initiating service(s) in 'bookstore_service'
error: ballerina/runtime:CallFailedException, message: call failed
        at bookstore_service:0.0.0:bookstore_service:0.0.0.<init>(bookstore_service.bal:35)
caused by error, message: error occurred while starting connection. Cannot send, channel has already failed: tcp://127.0.0.1:61616
        at ballerina/jms:new(connection.bal:29)
```

The ballerina-internal.log includes the following:
```cmd
[2018-06-28 22:18:19,528] ERROR {org.ballerinalang.net.jms.utils.BallerinaAdapter} - Error occurred while starting connection. 
javax.jms.JMSException: Cannot send, channel has already failed: tcp://127.0.0.1:61616
	at org.apache.activemq.util.JMSExceptionSupport.create(JMSExceptionSupport.java:72)
	at org.apache.activemq.ActiveMQConnection.syncSendPacket(ActiveMQConnection.java:1413)
	at org.apache.activemq.ActiveMQConnection.ensureConnectionInfoSent(ActiveMQConnection.java:1478)
	at org.apache.activemq.ActiveMQConnection.start(ActiveMQConnection.java:527)
	at org.ballerinalang.net.jms.nativeimpl.endpoint.connection.CreateConnection.execute(CreateConnection.java:62)
	at org.ballerinalang.util.program.BLangFunctions.invokeNativeCallable(BLangFunctions.java:386)
	at org.ballerinalang.util.program.BLangFunctions.invokeCallable(BLangFunctions.java:257)
	at org.ballerinalang.bre.bvm.CPU.invokeVirtualFunction(CPU.java:2903)
	at org.ballerinalang.bre.bvm.CPU.tryExec(CPU.java:415)
	at org.ballerinalang.bre.bvm.CPU.exec(CPU.java:148)
	at org.ballerinalang.bre.bvm.BLangScheduler.executeNow(BLangScheduler.java:80)
	at org.ballerinalang.util.program.BLangFunctions.invokeNonNativeCallable(BLangFunctions.java:317)
	at org.ballerinalang.util.program.BLangFunctions.invokeCallable(BLangFunctions.java:264)
	at org.ballerinalang.util.program.BLangFunctions.invokeCallable(BLangFunctions.java:244)
	at org.ballerinalang.util.program.BLangFunctions.invokePackageInitFunction(BLangFunctions.java:464)
	at org.ballerinalang.util.program.BLangFunctions.invokePackageInitFunction(BLangFunctions.java:473)
	at org.ballerinalang.util.program.BLangFunctions.invokePackageInitFunctions(BLangFunctions.java:123)
	at org.ballerinalang.BLangProgramRunner.runService(BLangProgramRunner.java:53)
	at org.ballerinalang.launcher.LauncherUtils.runServices(LauncherUtils.java:144)
	at org.ballerinalang.launcher.LauncherUtils.runProgram(LauncherUtils.java:114)
	at org.ballerinalang.launcher.Main$RunCmd.execute(Main.java:256)
	at java.util.Optional.ifPresent(Optional.java:159)
	at org.ballerinalang.launcher.Main.main(Main.java:66)
Caused by: org.apache.activemq.transport.InactivityIOException: Cannot send, channel has already failed: tcp://127.0.0.1:61616
	at org.apache.activemq.transport.AbstractInactivityMonitor.doOnewaySend(AbstractInactivityMonitor.java:328)
	at org.apache.activemq.transport.AbstractInactivityMonitor.oneway(AbstractInactivityMonitor.java:317)
	at org.apache.activemq.transport.TransportFilter.oneway(TransportFilter.java:94)
	at org.apache.activemq.transport.WireFormatNegotiator.oneway(WireFormatNegotiator.java:116)
	at org.apache.activemq.transport.MutexTransport.oneway(MutexTransport.java:68)
	at org.apache.activemq.transport.ResponseCorrelator.asyncRequest(ResponseCorrelator.java:81)
	at org.apache.activemq.transport.ResponseCorrelator.request(ResponseCorrelator.java:86)
	at org.apache.activemq.ActiveMQConnection.syncSendPacket(ActiveMQConnection.java:1388)
	... 21 more
 
[2018-06-28 22:18:19,533] ERROR {org.ballerinalang.net.jms.LoggingExceptionListener} - Connection exception received. 
javax.jms.JMSException: Unexpected error occurred: java.lang.NoClassDefFoundError: org/fusesource/hawtbuf/UTF8Buffer
	at org.apache.activemq.util.JMSExceptionSupport.create(JMSExceptionSupport.java:54)
	at org.apache.activemq.ActiveMQConnection.onAsyncException(ActiveMQConnection.java:1948)
	at org.apache.activemq.ActiveMQConnection.onException(ActiveMQConnection.java:1967)
	at org.apache.activemq.transport.TransportFilter.onException(TransportFilter.java:114)
	at org.apache.activemq.transport.ResponseCorrelator.onException(ResponseCorrelator.java:126)
	at org.apache.activemq.transport.TransportFilter.onException(TransportFilter.java:114)
	at org.apache.activemq.transport.TransportFilter.onException(TransportFilter.java:114)
	at org.apache.activemq.transport.WireFormatNegotiator.onException(WireFormatNegotiator.java:173)
	at org.apache.activemq.transport.AbstractInactivityMonitor.onException(AbstractInactivityMonitor.java:345)
	at org.apache.activemq.transport.TransportSupport.onException(TransportSupport.java:96)
	at org.apache.activemq.transport.tcp.TcpTransport.run(TcpTransport.java:224)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Unexpected error occurred: java.lang.NoClassDefFoundError: org/fusesource/hawtbuf/UTF8Buffer
	at org.apache.activemq.transport.tcp.TcpTransport.run(TcpTransport.java:222)
	... 1 more
Caused by: java.lang.NoClassDefFoundError: org/fusesource/hawtbuf/UTF8Buffer
	at org.apache.activemq.util.MarshallingSupport.readUTF(MarshallingSupport.java:229)
	at org.apache.activemq.util.MarshallingSupport.unmarshalPrimitive(MarshallingSupport.java:200)
	at org.apache.activemq.util.MarshallingSupport.unmarshalPrimitiveMap(MarshallingSupport.java:98)
	at org.apache.activemq.util.MarshallingSupport.unmarshalPrimitiveMap(MarshallingSupport.java:78)
	at org.apache.activemq.command.WireFormatInfo.unmarsallProperties(WireFormatInfo.java:177)
	at org.apache.activemq.command.WireFormatInfo.getProperty(WireFormatInfo.java:139)
	at org.apache.activemq.command.WireFormatInfo.getMaxInactivityDuration(WireFormatInfo.java:283)
	at org.apache.activemq.transport.InactivityMonitor.configuredOk(InactivityMonitor.java:106)
	at org.apache.activemq.transport.AbstractInactivityMonitor.startMonitorThreads(AbstractInactivityMonitor.java:448)
	at org.apache.activemq.transport.InactivityMonitor.startMonitorThreads(InactivityMonitor.java:88)
	at org.apache.activemq.transport.InactivityMonitor.processInboundWireFormatInfo(InactivityMonitor.java:61)
	at org.apache.activemq.transport.AbstractInactivityMonitor.onCommand(AbstractInactivityMonitor.java:294)
	at org.apache.activemq.transport.TransportSupport.doConsume(TransportSupport.java:83)
	at org.apache.activemq.transport.tcp.TcpTransport.doRun(TcpTransport.java:233)
	at org.apache.activemq.transport.tcp.TcpTransport.run(TcpTransport.java:215)
	... 1 more
Caused by: java.lang.ClassNotFoundException: org.fusesource.hawtbuf.UTF8Buffer
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 16 more
```

This PR updates the README.md to include this requirement.
